### PR TITLE
Use &amp; instead of & in frame src

### DIFF
--- a/code/FacebookLikebox.php
+++ b/code/FacebookLikebox.php
@@ -51,7 +51,7 @@ class FacebookLikebox extends ViewableData{
 			}
 		}
 
-		return $likeboxurl."?".http_build_query($arguments);
+		return $likeboxurl."?".str_replace("&", "&amp;", http_build_query($arguments));
 	}
 
 }


### PR DESCRIPTION
Using & in html can lead to issues and it fails HTML validation. This patch fixing the src to use &amp; instead
