### PR TITLE
Remove obsolete HTML attributes from I frame

### DIFF
--- a/templates/FacebookIframe.ss
+++ b/templates/FacebookIframe.ss
@@ -1,8 +1,5 @@
 <iframe
 	class="facebook_iframe"
 	src="$Src"
-	scrolling="no"
-	frameborder="0"
-	style="border:none; overflow:hidden; <% if Width %>width:{$Width}px;<% else %>width:100%;<% end_if %> <% if Height %>height:{$Height}px;<% end_if %>" 
-	allowTransparency="true"
+	style="border:none; overflow:hidden; background: transparent; <% if Width %>width:{$Width}px;<% else %>width:100%;<% end_if %> <% if Height %>height:{$Height}px;<% end_if %>" 
 ></iframe>


### PR DESCRIPTION
HTML Validation fails due to usage of obsolete attributes. Remove them
